### PR TITLE
Fix indentation in getRE helper

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -3,8 +3,8 @@
 from __future__ import print_function
 import re, sys, string
 
-def getRE(patttern):
-	return re.compile(patttern, re.I | re.L)
+def getRE(pattern):
+	return re.compile(pattern, re.I | re.L)
 
 def tr(fr, to, word):
 	"""poor man's unicode translate"""


### PR DESCRIPTION
## Summary
- keep original tab indentation for `getRE` return line

## Testing
- `python3 -m py_compile *.py`
